### PR TITLE
Fix attr value map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,76 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+docs/source/code/
+docs/source/_build
+
 # PyBuilder
 .pybuilder/
 target/

--- a/rm_bridge/changeset/change.py
+++ b/rm_bridge/changeset/change.py
@@ -25,12 +25,13 @@ CACHEKEY_REQTYPE_IDENTIFIER = "-3"
 REQ_TYPE_NAME = "Requirement"
 _ATTR_BLACKLIST = frozenset({("Type", "Folder")})
 _ATTR_VALUE_DEFAULT_MAP: cabc.Mapping[str, type] = {
-    "String": str,
-    "Enum": list,
-    "Date": datetime.datetime,
-    "Integer": int,
-    "Float": float,
     "Boolean": bool,
+    "Date": datetime.datetime,
+    "Datetime": datetime.datetime,
+    "Enum": list,
+    "Float": float,
+    "Integer": int,
+    "String": str,
 }
 
 
@@ -479,7 +480,13 @@ class TrackerChange:
         """Raise a if ."""
         reqtype_attr_defs = self.requirement_types[req_type_id]["attributes"]
         deftype = reqtype_attr_defs[name]["type"]
-        matches_type = isinstance(value, _ATTR_VALUE_DEFAULT_MAP[deftype])
+        if default_type := _ATTR_VALUE_DEFAULT_MAP.get(deftype):
+            matches_type = isinstance(value, default_type)
+        else:
+            matches_type = True
+            LOGGER.warning(
+                "Unknown field type '%s' for %s: %r", deftype, name, value
+            )
         if deftype == "Enum":
             options = self.data_type_definitions[name]
             is_faulty = not matches_type or not set(value) & set(options)


### PR DESCRIPTION
Instead of raising a `KeyError`, a warning is logged that an unknown type was found in the snapshot.

