### PR TITLE
Add `force` mode to CLI

### DIFF
--- a/capella_rm_bridge/__main__.py
+++ b/capella_rm_bridge/__main__.py
@@ -76,13 +76,6 @@ def create_errors_statement(errors: cabc.Iterable[str]) -> str:
     "synchronized",
 )
 @click.option(
-    "--no-safe-mode",
-    is_flag=True,
-    default=False,
-    help="Modifications are still done to a RequirementModule if an error in "
-    "another, independent module in the snapshot was identified.",
-)
-@click.option(
     "--gather-logs/--no-gather-logs",
     is_flag=True,
     default=True,
@@ -112,7 +105,6 @@ def main(
     push: bool,
     pull: bool,
     force: bool,
-    no_safe_mode: bool,
     gather_logs: bool,
     save_change_history: bool,
     save_error_log: bool,
@@ -153,7 +145,6 @@ def main(
             tconfig,
             module,
             force=force,
-            safe_mode=not no_safe_mode,
             gather_logs=gather_logs,
         )
 

--- a/capella_rm_bridge/__main__.py
+++ b/capella_rm_bridge/__main__.py
@@ -68,6 +68,14 @@ def create_errors_statement(errors: cabc.Iterable[str]) -> str:
     help="Pull the latest changes from remote.",
 )
 @click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="If a non RequirementModule-error was encountered only the object "
+    "and all related objects will be skipped. Intact objects will still be "
+    "synchronized",
+)
+@click.option(
     "--no-safe-mode",
     is_flag=True,
     default=False,
@@ -103,6 +111,7 @@ def main(
     dry_run: bool,
     push: bool,
     pull: bool,
+    force: bool,
     no_safe_mode: bool,
     gather_logs: bool,
     save_change_history: bool,
@@ -143,6 +152,7 @@ def main(
             model,
             tconfig,
             module,
+            force=force,
             safe_mode=not no_safe_mode,
             gather_logs=gather_logs,
         )

--- a/capella_rm_bridge/__main__.py
+++ b/capella_rm_bridge/__main__.py
@@ -167,6 +167,12 @@ def main(
                 changed_objs, module["id"], module["category"]
             )
 
+    if force:
+        commit_message = reporter.create_commit_message(snapshot["metadata"])
+        print(commit_message)
+        if reporter.store and not dry_run:
+            model.save(push=push, commit_msg=commit_message)
+
     if errors:
         error_statement = create_errors_statement(errors)
         print(error_statement)

--- a/capella_rm_bridge/__main__.py
+++ b/capella_rm_bridge/__main__.py
@@ -173,7 +173,9 @@ def main(
         commit_message = reporter.create_commit_message(snapshot["metadata"])
         print(commit_message)
         if reporter.store and not dry_run:
-            model.save(push=push, commit_msg=commit_message)
+            model.save(
+                push=push, commit_msg=commit_message, push_options=["skip.ci"]
+            )
 
     if errors:
         error_statement = create_errors_statement(errors)

--- a/capella_rm_bridge/__main__.py
+++ b/capella_rm_bridge/__main__.py
@@ -36,6 +36,9 @@ def write_change_set(change: str, module: dict[str, t.Any]) -> pathlib.Path:
     CHANGE_FOLDER_PATH.mkdir(parents=True, exist_ok=True)
     mid = module["id"].replace("/", "~")
     path = CHANGE_FOLDER_PATH / f"{mid}-{CHANGE_FILENAME}"
+    if path.is_file():
+        path.unlink(missing_ok=True)
+
     path.write_text(change, encoding="utf8")
     LOGGER.info("Change-set file %s written.", str(path))
     return path

--- a/capella_rm_bridge/auditing.py
+++ b/capella_rm_bridge/auditing.py
@@ -362,7 +362,7 @@ class RMReporter:
     def _assign_module(self, change: Change) -> LiveDocID | TrackerID | None:
         try:
             obj = self.model.by_uuid(change.parent)
-            while not isinstance(obj, reqif.RequirementsModule):
+            while not isinstance(obj, reqif.CapellaModule):
                 obj = obj.parent
             return obj.identifier
         except (KeyError, AttributeError):
@@ -447,11 +447,11 @@ class RMReporter:
             reqif.AttributeDefinition,
             reqif.AttributeDefinitionEnumeration,
             reqif.DataTypeDefinition,
-            reqif.EnumDataTypeDefinition,
+            reqif.EnumerationDataTypeDefinition,
             reqif.EnumValue,
             reqif.ModuleType,
             reqif.RelationType,
-            reqif.RequirementsTypesFolder,
+            reqif.CapellaTypesFolder,
             reqif.RequirementType,
         }
 

--- a/capella_rm_bridge/auditing.py
+++ b/capella_rm_bridge/auditing.py
@@ -407,7 +407,7 @@ class RMReporter:
             main_message = generate_main_message(self.categories.items())
             main = "\n".join((main_message, "\n".join(list_lines) + "\n"))
 
-        summary = f"{summary} from rev.{tool_metadata['revision']} [skip ci]\n"
+        summary = f"{summary} from rev.{tool_metadata['revision']}\n"
         rm_bridge_dependencies = get_dependencies()
         dependencies = "\n".join(
             (

--- a/capella_rm_bridge/auditing.py
+++ b/capella_rm_bridge/auditing.py
@@ -438,9 +438,9 @@ class RMReporter:
         return ext_count, mod_count, del_count, type_count
 
     def _is_reqtype_change(self, change: Change) -> bool:
-        if isinstance(change, Modification):
+        if isinstance(change, (Modification, Deletion)):
             obj = self.model.by_uuid(change.parent)
-        else:
+        elif isinstance(change, Extension):
             obj = self.model.by_uuid(change.uuid)
 
         return type(obj) in {

--- a/capella_rm_bridge/changeset/__init__.py
+++ b/capella_rm_bridge/changeset/__init__.py
@@ -108,7 +108,7 @@ def calculate_change_set(
     except (
         actiontypes.InvalidTrackerConfig,
         actiontypes.InvalidSnapshotModule,
-        change.MissingRequirementsModule,
+        change.MissingCapellaModule,
     ) as error:
         if gather_logs:
             message = _wrap_errors(module_id, [error.args[0]])

--- a/capella_rm_bridge/changeset/__init__.py
+++ b/capella_rm_bridge/changeset/__init__.py
@@ -103,8 +103,10 @@ def calculate_change_set(
         else:
             actions.extend(tchange.actions)
 
-        if force and tchange.actions not in actions:
-            actions.extend(tchange.actions)
+        if force and tchange.actions:
+            for action in tchange.actions:
+                if action not in actions:
+                    actions.append(action)
     except (
         actiontypes.InvalidTrackerConfig,
         actiontypes.InvalidSnapshotModule,

--- a/capella_rm_bridge/changeset/__init__.py
+++ b/capella_rm_bridge/changeset/__init__.py
@@ -100,8 +100,10 @@ def calculate_change_set(
                 module_id, tchange.errors, include_start=not force
             )
             errors.append(message)
+        else:
+            actions.extend(tchange.actions)
 
-        if force:
+        if force and tchange.actions not in actions:
             actions.extend(tchange.actions)
     except (
         actiontypes.InvalidTrackerConfig,

--- a/capella_rm_bridge/changeset/change.py
+++ b/capella_rm_bridge/changeset/change.py
@@ -1087,9 +1087,16 @@ class TrackerChange:
                 return None
             return {"parent": decl.UUIDReference(attrdef.uuid), "modify": mods}
         except KeyError:
-            return self.attribute_definition_create_action(
-                name, data, reqtype.identifier
-            )
+            try:
+                return self.attribute_definition_create_action(
+                    name, data, reqtype.identifier
+                )
+            except act.InvalidAttributeDefinition as error:
+                self._handle_user_error(
+                    f"In RequirementType {reqtype.long_name!r}: "
+                    + error.args[0]
+                )
+                return None
 
 
 def make_requirement_delete_actions(

--- a/capella_rm_bridge/changeset/change.py
+++ b/capella_rm_bridge/changeset/change.py
@@ -483,7 +483,7 @@ class TrackerChange:
             base["folders"] = []
             child: act.WorkItem
             for child in item["children"]:
-                key = "folders" if child.get("children") else "requirements"
+                key = "folders" if "children" in child else "requirements"
                 creq = self.reqfinder.work_item_by_identifier(child["id"])
                 if creq is None:
                     child_actions = self.yield_requirements_create_actions(
@@ -920,7 +920,7 @@ class TrackerChange:
             child_folder_ids = set[RMIdentifier]()
             for child in children:
                 cid = RMIdentifier(str(child["id"]))
-                if child.get("children", []):
+                if "children" in child:
                     key = "folders"
                     child_folder_ids.add(cid)
                 else:

--- a/capella_rm_bridge/changeset/change.py
+++ b/capella_rm_bridge/changeset/change.py
@@ -35,7 +35,7 @@ _ATTR_VALUE_DEFAULT_MAP: cabc.Mapping[str, type] = {
 }
 
 
-WorkItem = t.Union[reqif.Requirement, reqif.RequirementsFolder]
+WorkItem = t.Union[reqif.Requirement, reqif.Folder]
 RMIdentifier = t.NewType("RMIdentifier", str)
 
 
@@ -45,8 +45,8 @@ class _AttributeValueBuilder(t.NamedTuple):
     value: act.Primitive | None
 
 
-class MissingRequirementsModule(Exception):
-    """A ``RequirementsModule`` with matching UUID could not be found."""
+class MissingCapellaModule(Exception):
+    """A ``CapellaModule`` with matching UUID could not be found."""
 
 
 class TrackerChange:
@@ -216,7 +216,7 @@ class TrackerChange:
             ) from error
 
         if self.req_module is None:
-            raise MissingRequirementsModule(
+            raise MissingCapellaModule(
                 f"No RequirementsModule with UUID {module_uuid!r} found in "
                 + repr(self.model.info)
             )
@@ -252,7 +252,7 @@ class TrackerChange:
         delete action was removed.
         """
         key = "requirements"
-        if isinstance(requirement, reqif.RequirementsFolder):
+        if isinstance(requirement, reqif.Folder):
             key = "folders"
 
         try:
@@ -903,7 +903,7 @@ class TrackerChange:
         cf_creations: list[dict[str, t.Any] | decl.UUIDReference] = []
         containers = [cr_creations, cf_creations]
         child_mods: list[dict[str, t.Any]] = []
-        if isinstance(req, reqif.RequirementsFolder):
+        if isinstance(req, reqif.Folder):
             child_req_ids = set[RMIdentifier]()
             child_folder_ids = set[RMIdentifier]()
             for child in children:

--- a/capella_rm_bridge/changeset/find.py
+++ b/capella_rm_bridge/changeset/find.py
@@ -35,25 +35,29 @@ class ReqFinder:
             LOGGER.info("No %s found with %s: %r", types, attr, value)
         return None
 
-    def reqmodule(self, uuid: str) -> reqif.RequirementsModule | None:
-        """Try to return the ``RequirementsModule``."""
-        return self._get(uuid, reqif.XT_MODULE, attr="uuid")
+    def reqmodule(self, uuid: str) -> reqif.CapellaModule | None:
+        """Try to return the ``CapellaModule``."""
+        return self._get(uuid, reqif.CapellaModule.__name__, attr="uuid")
 
     def reqtypesfolder_by_identifier(
         self,
         identifier: int | str,
         below: crosslayer.BaseArchitectureLayer
-        | reqif.RequirementsModule
+        | reqif.CapellaModule
         | None = None,
-    ) -> reqif.RequirementsTypesFolder | None:
+    ) -> reqif.CapellaTypesFolder | None:
         """Try to return the ``RequirementTypesFolder``."""
-        return self._get(str(identifier), reqif.XT_REQ_TYPES_F, below=below)
+        return self._get(
+            str(identifier), reqif.CapellaTypesFolder.__name__, below=below
+        )
 
     def reqtype_by_identifier(
         self, identifier: int | str, below: reqif.ReqIFElement | None = None
-    ) -> reqif.RequirementsType | None:
+    ) -> reqif.RequirementType | None:
         """Try to return a ``RequirementType``."""
-        return self._get(str(identifier), reqif.XT_REQ_TYPE, below=below)
+        return self._get(
+            str(identifier), reqif.RequirementType.__name__, below=below
+        )
 
     def attribute_definition_by_identifier(
         self, xtype: str, identifier: str, below: reqif.ReqIFElement | None
@@ -65,21 +69,27 @@ class ReqFinder:
         self,
         identifier: int | str,
         below: reqif.ReqIFElement | None = None,
-    ) -> reqif.Requirement | reqif.RequirementsFolder | None:
+    ) -> reqif.Requirement | reqif.Folder | None:
         """Try to return a ``Requirement``/``RequirementsFolder``."""
         return self._get(
-            str(identifier), reqif.XT_REQUIREMENT, reqif.XT_FOLDER, below=below
+            str(identifier),
+            reqif.Requirement.__name__,
+            reqif.Folder.__name__,
+            below=below,
         )
 
     def enum_data_type_definition_by_long_name(
         self, long_name: str, below: reqif.ReqIFElement | None
-    ) -> reqif.EnumDataTypeDefinition | None:
-        """Try to return an ``EnumDataTypeDefinition``.
+    ) -> reqif.EnumerationDataTypeDefinition | None:
+        """Try to return an ``EnumerationDataTypeDefinition``.
 
         The object is matched with given ``long_name``.
         """
         return self._get(
-            long_name, reqif.XT_REQ_TYPE_ENUM, attr="long_name", below=below
+            long_name,
+            reqif.EnumerationDataTypeDefinition.__name__,
+            attr="long_name",
+            below=below,
         )
 
     def enum_value_by_long_name(
@@ -89,5 +99,6 @@ class ReqFinder:
 
         The object is matched with given ``long_name``.
         """
-        xt = reqif.XT_REQ_TYPE_ATTR_ENUM
-        return self._get(long_name, xt, attr="long_name", below=below)
+        return self._get(
+            long_name, reqif.EnumValue.__name__, attr="long_name", below=below
+        )

--- a/tests/data/changesets/create.yaml
+++ b/tests/data/changesets/create.yaml
@@ -14,8 +14,6 @@
             values:
               - long_name: Unset
                 promise_id: EnumValue Type Unset
-              - long_name: Folder
-                promise_id: EnumValue Type Folder
               - long_name: Functional
                 promise_id: EnumValue Type Functional
             promise_id: EnumerationDataTypeDefinition Type

--- a/tests/data/model/RM Bridge.capella
+++ b/tests/data/model/RM Bridge.capella
@@ -1839,8 +1839,6 @@ The predator is far away</bodies>
               id="686e198b-8baf-49f9-9d85-24571bd05d93" ReqIFLongName="Type">
             <specifiedValues xsi:type="Requirements:EnumValue" id="61d37f6e-b821-49fa-b68d-c4ff48b8cbbf"
                 ReqIFLongName="Unset"/>
-            <specifiedValues xsi:type="Requirements:EnumValue" id="b8e062d5-1181-4a69-9b25-15fd738b15ed"
-                ReqIFLongName="Folder"/>
             <specifiedValues xsi:type="Requirements:EnumValue" id="5a03662a-d602-4524-8706-5bf83275ee2a"
                 ReqIFLongName="Functional"/>
           </ownedDefinitionTypes>

--- a/tests/data/snapshots/snapshot.yaml
+++ b/tests/data/snapshots/snapshot.yaml
@@ -7,7 +7,6 @@
   data_types: # Enumeration Data Type Definitions
     Type:
       - Unset
-      - Folder
       - Functional
     Release:
       - Feature Rel. 1
@@ -47,9 +46,6 @@
       text: <p>Test Description</p>
       type: system_requirement # WorkItemType ID NOT name
 
-      attributes:
-        Type: [Folder] # artifact from CODEBEAMER and cleaned in RM Bridge
-
       children: # Folder b/c non-empty children
         - id: REQ-002
           long_name: Function Requirement
@@ -65,8 +61,6 @@
         - id: REQ-003
           long_name: Kinds
           type: software_requirement
-          attributes:
-            Type: [Folder]
           children:
             - id: REQ-004
               long_name: Kind Requirement

--- a/tests/data/snapshots/snapshot1.yaml
+++ b/tests/data/snapshots/snapshot1.yaml
@@ -7,7 +7,6 @@
   data_types:
     Type:
       - Unset
-      - Folder
       - Functional
       - Non-Functional
     Release:
@@ -68,8 +67,6 @@
       long_name: Functional Requirements
       text: <p>Brand new</p>
       type: software_requirement
-      attributes:
-        Type: [Folder]
       children:
         - id: REQ-004
           long_name: Function Requirement

--- a/tests/data/snapshots/snapshot2.yaml
+++ b/tests/data/snapshots/snapshot2.yaml
@@ -7,7 +7,6 @@
   data_types:
     Type:
       - Unset
-      - Folder
       - Non-Functional
   requirement_types:
     system_requirement:

--- a/tests/test_auditing.py
+++ b/tests/test_auditing.py
@@ -336,6 +336,8 @@ def test_create_commit_message(migration_model: capellambse.MelodyModel):
     req_uuid = "163394f5-c1ba-4712-a238-b0b143c66aed"
     reqtypesfolder_uuid = "a15e8b60-bf39-47ba-b7c7-74ceecb25c9c"
     dtdef_uuid = "686e198b-8baf-49f9-9d85-24571bd05d93"
+    req = migration_model.by_uuid(req_uuid)
+    req.parent.requirements.remove(req)
     changes: list[auditing.Change] = [
         auditing.Deletion(
             parent="9a9b5a8f-a6ad-4610-9e88-3b5e9c943c19",

--- a/tests/test_auditing.py
+++ b/tests/test_auditing.py
@@ -374,7 +374,7 @@ def test_create_commit_message(migration_model: capellambse.MelodyModel):
     commit_message = reporter.create_commit_message(tool_metadata)
 
     assert commit_message.startswith(
-        "Updated model with RM content from rev.123 [skip ci]\n"
+        "Updated model with RM content from rev.123\n"
         "\n"
         "Synchronized 1 category1 and 1 category2:\n"
         "- 1: created: 1; updated: 1; deleted: 1; type-changes: 0\n"

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -363,6 +363,25 @@ class TestModActions(ActionsTest):
 
         assert caplog.messages[0].endswith(INVALID_ATTR_DEF_ERROR_MSG)
 
+    def test_faulty_simple_attributes_log_AttributeError(
+        self,
+        migration_model: capellambse.MelodyModel,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test logging ``AttributeError`` on faulty simple attributes."""
+        tracker = copy.deepcopy(self.tracker)
+        titem = tracker["items"][0]
+        titem["imagination"] = 1
+        message_end = (
+            "Invalid module 'project/space/example title'. Invalid "
+            "workitem 'REQ-001'. imagination isn't defined on Folder"
+        )
+
+        with caplog.at_level(logging.ERROR):
+            self.tracker_change(migration_model, tracker, gather_logs=False)
+
+        assert caplog.messages[0].endswith(message_end)
+
     def test_InvalidAttributeDefinition_errors_are_gathered(
         self, migration_model: capellambse.MelodyModel
     ) -> None:

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -205,7 +205,7 @@ class TestCreateActions(ActionsTest):
         first_child = titem["children"][0]
         first_child["attributes"][attr] = faulty_value  # type:ignore[index]
         message_end = (
-            f"Invalid field found: {key} '{faulty_value}' for '{attr}'"
+            f"Invalid field found: {key} {faulty_value!r} for {attr!r}"
         )
 
         with caplog.at_level(logging.ERROR):
@@ -227,7 +227,7 @@ class TestCreateActions(ActionsTest):
             ] = faulty_value  # type:ignore[index]
             messages.append(
                 "Invalid workitem 'REQ-002'. "
-                f"Invalid field found: {key} '{faulty_value}' for '{attr}'"
+                f"Invalid field found: {key} {faulty_value!r} for {attr!r}"
             )
 
         change = self.tracker_change(clean_model, tracker, gather_logs=True)
@@ -338,7 +338,7 @@ class TestModActions(ActionsTest):
         first_child = titem["children"][0]
         first_child["attributes"][attr] = faulty_value
         message_end = (
-            f"Invalid field found: {key} '{faulty_value}' for '{attr}'"
+            f"Invalid field found: {key} {faulty_value!r} for {attr!r}"
         )
 
         with caplog.at_level(logging.ERROR):
@@ -479,7 +479,7 @@ class TestCalculateChangeSet(ActionsTest):
         config = copy.deepcopy(TEST_CONFIG["modules"][0])
         del config["capella-uuid"]  # type:ignore[misc]
         message = (
-            "The given module configuration is missing 'UUID' of the target "
+            "The given module configuration is missing UUID of the target "
             "RequirementsModule"
         )
 
@@ -520,7 +520,7 @@ class TestCalculateChangeSet(ActionsTest):
         tconfig = TEST_CONFIG["modules"][0]
         message = (
             "Skipping module: MISSING ID. "
-            "In the snapshot the module is missing an 'id' key"
+            "In the snapshot the module is missing an id key"
         )
 
         with caplog.at_level(logging.ERROR):
@@ -537,7 +537,7 @@ class TestCalculateChangeSet(ActionsTest):
         config = copy.deepcopy(TEST_CONFIG["modules"][0])
         del config["capella-uuid"]  # type:ignore[misc]
         message = (
-            "The given module configuration is missing 'UUID' of the target "
+            "The given module configuration is missing UUID of the target "
             "RequirementsModule"
         )
 
@@ -560,7 +560,7 @@ class TestCalculateChangeSet(ActionsTest):
             "In RequirementType 'System Requirement': Invalid "
             "AttributeDefinitionEnumeration found: 'Release'. Missing its "
             "datatype definition in `data_types`.\n"
-            "Invalid workitem 'REQ-002'. Invalid field found: Release. "
+            "Invalid workitem 'REQ-002'. Invalid field found: 'Release'. "
             "Missing its datatype definition in `data_types`."
         )
 
@@ -604,7 +604,7 @@ class TestCalculateChangeSet(ActionsTest):
             ] = faulty_value  # type:ignore[index]
             messages.append(
                 "Invalid workitem 'REQ-002'. "
-                + f"Invalid field found: {key} '{faulty_value}' for '{attr}'"
+                + f"Invalid field found: {key} {faulty_value!r} for {attr!r}"
             )
         del titem["children"][1]["type"]
         tconfig = TEST_CONFIG["modules"][0]

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -113,7 +113,7 @@ class TestTrackerChangeInit(ActionsTest):
         """
         del clean_model.la.requirement_modules[0]
 
-        with pytest.raises(change.MissingRequirementsModule):
+        with pytest.raises(change.MissingCapellaModule):
             self.tracker_change(clean_model, TEST_SNAPSHOT[0])
 
     def test_init_on_missing_module_id_raises_InvalidSnapshotModule(


### PR DESCRIPTION
With force mode enabled errors during the `ChangeSet` calculation won't cause a module skip. It will skip the erroneous model object and all related objects depending on it. This PR starts with including error handling of faulty `AttributeDefinitions` whose data-type can't be found in the snapshot. All related `AttributeValue`s will be skipped too. These events will be added to the log.

This PR also solves #29 by implementing @Wuestengecko's idea by using the `children` attribute correctly. If it is there, the RM-Bridge will identify the workitem as a `Folder` now.