### PR TITLE
feat: Anticipate IDs usage

### DIFF
--- a/capella_rm_bridge/__main__.py
+++ b/capella_rm_bridge/__main__.py
@@ -79,7 +79,7 @@ def write_change_set(change: str, module: dict[str, t.Any]) -> pathlib.Path:
 @click.option(
     "--pull/--no-pull",
     is_flag=True,
-    default=True,
+    default=None,
     help="Pull the latest changes from remote.",
 )
 @click.option(
@@ -118,7 +118,7 @@ def main(
     snapshotfile: t.TextIO,
     dry_run: bool,
     push: bool,
-    pull: bool,
+    pull: bool | None,
     force: bool,
     gather_logs: bool,
     save_change_history: bool,
@@ -147,7 +147,7 @@ def main(
 
     config = yaml.safe_load(conffile)
     params = config["model"]
-    if "git" in config["model"]["path"]:
+    if pull is not None:
         params["update_cache"] = pull
 
     model = capellambse.MelodyModel(**params)

--- a/capella_rm_bridge/changeset/__init__.py
+++ b/capella_rm_bridge/changeset/__init__.py
@@ -74,8 +74,7 @@ def calculate_change_set(
         dismissed.
     gather_logs
         If ``True`` all error messages are gathered in
-        :attribute:`~capella_rm_bridge.changeset.change.TrackerChange.errors`
-        instead of being immediately logged.
+        `TrackerChange.errors` instead of being immediately logged.
 
     Returns
     -------

--- a/capella_rm_bridge/changeset/actiontypes.py
+++ b/capella_rm_bridge/changeset/actiontypes.py
@@ -45,7 +45,7 @@ class InvalidTrackerConfig(Exception):
 class WorkItem(te.TypedDict, total=False):
     """A workitem from the snapshot."""
 
-    id: te.Required[int]
+    id: te.Required[str]
     long_name: str
     text: str
     type: str

--- a/capella_rm_bridge/changeset/actiontypes.py
+++ b/capella_rm_bridge/changeset/actiontypes.py
@@ -10,9 +10,12 @@ import typing as t
 import typing_extensions as te
 
 Primitive = t.Union[int, float, str, list[str], bool, datetime.datetime]
+"""Type alias for primitive values."""
 
 
 class WorkitemTypeConfig(te.TypedDict):
+    """A configeration for workitem types."""
+
     name: str
     fields: te.NotRequired[cabc.Sequence[str]]
 
@@ -25,9 +28,12 @@ TrackerConfig = te.TypedDict(
         "id": str,
     },
 )
+"""A configuration of an RM module."""
 
 
 class Config(te.TypedDict):
+    """A configuration of an RM synchronization plan."""
+
     modules: cabc.Sequence[TrackerConfig]
     trackers: cabc.Sequence[TrackerConfig]
 
@@ -37,6 +43,8 @@ class InvalidTrackerConfig(Exception):
 
 
 class WorkItem(te.TypedDict, total=False):
+    """A workitem from the snapshot."""
+
     id: te.Required[int]
     long_name: str
     text: str
@@ -45,13 +53,31 @@ class WorkItem(te.TypedDict, total=False):
     children: cabc.Sequence[WorkItem]
 
 
+class DataType(te.TypedDict):
+    """A data_type from the snapshot."""
+
+    long_name: str
+    values: list[DataTypeValue]
+
+
+class DataTypeValue(te.TypedDict):
+    """An enum value/option from the snapshot."""
+
+    id: str
+    long_name: str
+
+
 class MetaData(te.TypedDict):
+    """Metadata of a snapshot."""
+
     tool: str
     revision: str
     connector: str
 
 
 class TrackerSnapshot(te.TypedDict):
+    """A snapshot of a whole module from the RM tool."""
+
     id: int
     version: int | float
     data_types: cabc.Mapping[str, cabc.Sequence[str]]
@@ -60,22 +86,31 @@ class TrackerSnapshot(te.TypedDict):
 
 
 class Snapshot(te.TypedDict):
+    """A whole snapshot from the RM tool that may have multiple modules."""
+
     metadata: MetaData
     modules: cabc.Sequence[TrackerSnapshot]
 
 
-class AttributeDefinition(te.TypedDict):
-    type: str
-
-
 class RequirementType(t.TypedDict):
+    """A requirement type from the snapshot."""
+
     long_name: str
     attributes: cabc.Mapping[
         str, t.Union[AttributeDefinition, EnumAttributeDefinition]
     ]
 
 
+class AttributeDefinition(te.TypedDict):
+    """An attribute definition from the snapshot."""
+
+    long_name: str
+    type: str
+
+
 class EnumAttributeDefinition(AttributeDefinition, total=False):
+    """An attribute definition with `type == enum` from the snapshot."""
+
     values: list[str]
     multi_values: bool
 

--- a/capella_rm_bridge/changeset/change.py
+++ b/capella_rm_bridge/changeset/change.py
@@ -641,7 +641,7 @@ class TrackerChange:
 
         Raises
         ------
-        capella_rm_bridge.actiontypes.InvalidFieldValue
+        capella_rm_bridge.changeset.actiontypes.InvalidFieldValue
             If the types are not matching, if the used data_type
             definition is missing in the snapshot or the used options
             on an `EnumerationAttributeValue` are missing in the

--- a/capella_rm_bridge/changeset/change.py
+++ b/capella_rm_bridge/changeset/change.py
@@ -457,7 +457,7 @@ class TrackerChange:
         return base
 
     def yield_requirements_create_actions(
-        self, item: dict[str, t.Any] | act.WorkItem
+        self, item: act.WorkItem
     ) -> cabc.Iterator[dict[str, t.Any]]:
         """Yield actions for creating Requirements or Folders.
 
@@ -517,12 +517,12 @@ class TrackerChange:
                 if "children" in child:
                     key = "folders"
                     creq = find.find_by_identifier(
-                        self.model, str(child["id"]), "Folder"
+                        self.model, child["id"], "Folder"
                     )
                 else:
                     key = "requirements"
                     creq = find.find_by_identifier(
-                        self.model, str(child["id"]), "Requirement"
+                        self.model, child["id"], "Requirement"
                     )
 
                 if creq is None:

--- a/capella_rm_bridge/changeset/change.py
+++ b/capella_rm_bridge/changeset/change.py
@@ -1117,6 +1117,7 @@ class TrackerChange:
             self.model, f"{id} {req_type_id}", deftype, below=self.reqt_folder
         )
         attr = req.attributes.by_definition(attrdef, single=True)
+        assert attrdef is not None
         if isinstance(attr, reqif.EnumerationValueAttribute):
             assert isinstance(valueid, list)
             actual = set(attr.values.by_identifier)

--- a/capella_rm_bridge/changeset/find.py
+++ b/capella_rm_bridge/changeset/find.py
@@ -79,27 +79,22 @@ class ReqFinder:
             str(identifier), reqif.Requirement.__name__, below=below
         )
 
-    def enum_data_type_definition_by_long_name(
-        self, long_name: str, below: reqif.ReqIFElement | None
+    def enum_data_type_definition_by_identifier(
+        self, id: str, below: reqif.ReqIFElement | None
     ) -> reqif.EnumerationDataTypeDefinition | None:
         """Try to return an ``EnumerationDataTypeDefinition``.
 
         The object is matched with given ``long_name``.
         """
         return self._get(
-            long_name,
-            reqif.EnumerationDataTypeDefinition.__name__,
-            attr="long_name",
-            below=below,
+            id, reqif.EnumerationDataTypeDefinition.__name__, below=below
         )
 
-    def enum_value_by_long_name(
-        self, long_name: str, below: reqif.ReqIFElement | None = None
+    def enum_value_by_identifier(
+        self, id: str, below: reqif.ReqIFElement | None = None
     ) -> reqif.EnumValue | None:
         """Try to return an ``EnumValue``.
 
         The object is matched with given ``long_name``.
         """
-        return self._get(
-            long_name, reqif.EnumValue.__name__, attr="long_name", below=below
-        )
+        return self._get(id, reqif.EnumValue.__name__, below=below)

--- a/capella_rm_bridge/changeset/find.py
+++ b/capella_rm_bridge/changeset/find.py
@@ -31,6 +31,6 @@ def find_by(
 
 def find_by_identifier(
     model: capellambse.MelodyModel, id: str, *xtypes: str, **kw
-) -> reqif.ReqIFElement:
+) -> reqif.ReqIFElement | None:
     """Try to return a model object by its ``identifier``."""
     return find_by(model, id, *xtypes, **kw)

--- a/capella_rm_bridge/changeset/find.py
+++ b/capella_rm_bridge/changeset/find.py
@@ -9,92 +9,28 @@ import typing as t
 
 import capellambse
 from capellambse.extensions import reqif
-from capellambse.model import crosslayer
 
 LOGGER = logging.getLogger(__name__)
 
 
-class ReqFinder:
-    """Find ReqIF elements in a ``MelodyModel`` easily and efficiently."""
+def find_by(
+    model: capellambse.MelodyModel,
+    value: t.Any,
+    *xtypes: str,
+    attr: str = "identifier",
+    below: reqif.ReqIFElement | None = None,
+) -> reqif.ReqIFElement | None:
+    try:
+        objs = model.search(*xtypes, below=below)
+        return getattr(objs, f"by_{attr}")(value, single=True)
+    except KeyError:
+        types = " or ".join(xt.split(":")[-1] for xt in xtypes)
+        LOGGER.info("No %s found with %s: %r", types, attr, value)
+    return None
 
-    def __init__(self, model: capellambse.MelodyModel) -> None:
-        self.model = model
 
-    def _get(
-        self,
-        value: t.Any,
-        *xtypes: str,
-        attr: str = "identifier",
-        below: reqif.ReqIFElement | None = None,
-    ) -> reqif.ReqIFElement | None:
-        try:
-            objs = self.model.search(*xtypes, below=below)
-            return getattr(objs, f"by_{attr}")(value, single=True)
-        except KeyError:
-            types = " or ".join(xt.split(":")[-1] for xt in xtypes)
-            LOGGER.info("No %s found with %s: %r", types, attr, value)
-        return None
-
-    def reqmodule(self, uuid: str) -> reqif.CapellaModule | None:
-        """Try to return the ``CapellaModule``."""
-        return self._get(uuid, reqif.CapellaModule.__name__, attr="uuid")
-
-    def reqtypesfolder_by_identifier(
-        self,
-        identifier: int | str,
-        below: crosslayer.BaseArchitectureLayer
-        | reqif.CapellaModule
-        | None = None,
-    ) -> reqif.CapellaTypesFolder | None:
-        """Try to return the ``RequirementTypesFolder``."""
-        return self._get(
-            str(identifier), reqif.CapellaTypesFolder.__name__, below=below
-        )
-
-    def reqtype_by_identifier(
-        self, identifier: int | str, below: reqif.ReqIFElement | None = None
-    ) -> reqif.RequirementType | None:
-        """Try to return a ``RequirementType``."""
-        return self._get(
-            str(identifier), reqif.RequirementType.__name__, below=below
-        )
-
-    def attribute_definition_by_identifier(
-        self, xtype: str, identifier: str, below: reqif.ReqIFElement | None
-    ) -> reqif.AttributeDefinition | reqif.AttributeDefinitionEnumeration:
-        """Try to return an ``AttributeDefinition``-/``Enumeration``."""
-        return self._get(identifier, xtype, below=below)
-
-    def folder_by_identifier(
-        self, identifier: int | str, below: reqif.ReqIFElement | None = None
-    ) -> reqif.Folder | None:
-        """Try to return a ``Folder``."""
-        return self._get(str(identifier), reqif.Folder.__name__, below=below)
-
-    def requirement_by_identifier(
-        self, identifier: int | str, below: reqif.ReqIFElement | None = None
-    ) -> reqif.Requirement | None:
-        """Try to return a ``Requirement``."""
-        return self._get(
-            str(identifier), reqif.Requirement.__name__, below=below
-        )
-
-    def enum_data_type_definition_by_identifier(
-        self, id: str, below: reqif.ReqIFElement | None
-    ) -> reqif.EnumerationDataTypeDefinition | None:
-        """Try to return an ``EnumerationDataTypeDefinition``.
-
-        The object is matched with given ``long_name``.
-        """
-        return self._get(
-            id, reqif.EnumerationDataTypeDefinition.__name__, below=below
-        )
-
-    def enum_value_by_identifier(
-        self, id: str, below: reqif.ReqIFElement | None = None
-    ) -> reqif.EnumValue | None:
-        """Try to return an ``EnumValue``.
-
-        The object is matched with given ``long_name``.
-        """
-        return self._get(id, reqif.EnumValue.__name__, below=below)
+def find_by_identifier(
+    model: capellambse.MelodyModel, id: str, *xtypes: str, **kw
+) -> reqif.ReqIFElement:
+    """Try to return a model object by its ``identifier``."""
+    return find_by(model, id, *xtypes, **kw)

--- a/capella_rm_bridge/changeset/snapshot_input.schema.json
+++ b/capella_rm_bridge/changeset/snapshot_input.schema.json
@@ -59,9 +59,29 @@
               "patternProperties": {
                 ".": {
                   "description": "The values that are available for this EnumerationDataTypeDefinition. They are sometimes called \"options\"",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
+                  "type": "object",
+                  "properties": {
+                    "long_name": {
+                      "description": "Value of the \"Long Name\" field in Capella. Here it is the long name of the EnumerationDataTypeDefinition.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "EnumValues in Capella.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "Value of the \"Identifier\" field in Capella. Here it is the identifier of the EnumValue.",
+                            "type": "string"
+                          },
+                          "long_name": {
+                            "description": "Value of the \"Long Name\" field in Capella. Here it is the long name of the EnumValue.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -93,6 +113,10 @@
                           "oneOf": [
                             {
                               "properties": {
+                                "long_name": {
+                                  "description": "Value of the \"Long Name\" field in Capella. Here it is the long name of the AttributeDefinition.",
+                                  "type": "string"
+                                },
                                 "type": {
                                   "type": "string",
                                   "enum": [
@@ -108,6 +132,10 @@
                             },
                             {
                               "properties": {
+                                "long_name": {
+                                  "description": "Value of the \"Long Name\" field in Capella. Here it is the long name of the EnumerationAttributeDefinition.",
+                                  "type": "string"
+                                },
                                 "type": {
                                   "type": "string",
                                   "const": "Enum"

--- a/docs/source/snapshot.rst
+++ b/docs/source/snapshot.rst
@@ -208,8 +208,9 @@ are supported:
   calculation.
 
 With the ``children`` key the hierarchical structure of the workitems is
-exported and empty children will result in a ``Requirement``. Conversely
-non-empty children will cause change action on a ``Folder``.
+exported. The existance of a ``children`` key will result in a ``Folder``.
+Conversely if there is no ``children`` key will cause change action on a
+``Requirement``.
 
 Complete snapshot
 =================

--- a/tests/data/changesets/create.yaml
+++ b/tests/data/changesets/create.yaml
@@ -10,72 +10,78 @@
       - long_name: Types
         identifier: "-2"
         data_type_definitions:
-          - long_name: Type
+          - identifier: type
+            long_name: Type
             values:
-              - long_name: Unset
-                promise_id: EnumValue Type Unset
-              - long_name: Functional
-                promise_id: EnumValue Type Functional
-            promise_id: EnumerationDataTypeDefinition Type
+              - identifier: unset
+                long_name: Unset
+                promise_id: EnumValue type unset
+              - identifier: functional
+                long_name: Functional
+                promise_id: EnumValue type functional
+            promise_id: EnumerationDataTypeDefinition type
             _type: EnumerationDataTypeDefinition
-          - long_name: Release
+          - identifier: release
+            long_name: Release
             values:
-              - long_name: Feature Rel. 1
-                promise_id: EnumValue Release Feature Rel. 1
-              - long_name: Feature Rel. 2
-                promise_id: EnumValue Release Feature Rel. 2
-            promise_id: EnumerationDataTypeDefinition Release
+              - identifier: featureRel.1
+                long_name: Feature Rel. 1
+                promise_id: EnumValue release featureRel.1
+              - identifier: featureRel.2
+                long_name: Feature Rel. 2
+                promise_id: EnumValue release featureRel.2
+            promise_id: EnumerationDataTypeDefinition release
             _type: EnumerationDataTypeDefinition
         requirement_types:
           - identifier: system_requirement
             long_name: System Requirement
             promise_id: RequirementType system_requirement
             attribute_definitions:
-              - long_name: Capella ID
-                identifier: Capella ID system_requirement
-                promise_id: AttributeDefinition Capella ID system_requirement
+              - identifier: capellaID system_requirement
+                long_name: Capella ID
+                promise_id: AttributeDefinition capellaID system_requirement
                 _type: AttributeDefinition
-              - long_name: Type
-                identifier: Type system_requirement
-                data_type: !promise EnumerationDataTypeDefinition Type
+              - identifier: type system_requirement
+                long_name: Type
+                data_type: !promise EnumerationDataTypeDefinition type
                 multi_valued: false
-                promise_id: AttributeDefinitionEnumeration Type system_requirement
+                promise_id: AttributeDefinitionEnumeration type system_requirement
                 _type: AttributeDefinitionEnumeration
-              - long_name: Submitted at
-                identifier: Submitted at system_requirement
-                promise_id: AttributeDefinition Submitted at system_requirement
+              - identifier: submittedAt system_requirement
+                long_name: Submitted at
+                promise_id: AttributeDefinition submittedAt system_requirement
                 _type: AttributeDefinition
-              - long_name: Release
-                identifier: Release system_requirement
-                data_type: !promise EnumerationDataTypeDefinition Release
+              - identifier: release system_requirement
+                long_name: Release
+                data_type: !promise EnumerationDataTypeDefinition release
                 multi_valued: true
-                promise_id: AttributeDefinitionEnumeration Release system_requirement
+                promise_id: AttributeDefinitionEnumeration release system_requirement
                 _type: AttributeDefinitionEnumeration
           - identifier: software_requirement
             long_name: Software Requirement
             promise_id: RequirementType software_requirement
             attribute_definitions:
-              - long_name: Capella ID
-                identifier: Capella ID software_requirement
-                promise_id: AttributeDefinition Capella ID software_requirement
+              - identifier: capellaID software_requirement
+                long_name: Capella ID
+                promise_id: AttributeDefinition capellaID software_requirement
                 _type: AttributeDefinition
-              - long_name: Type
-                identifier: Type software_requirement
-                data_type: !promise EnumerationDataTypeDefinition Type
+              - identifier: type software_requirement
+                long_name: Type
+                data_type: !promise EnumerationDataTypeDefinition type
                 multi_valued: false
-                promise_id: AttributeDefinitionEnumeration Type software_requirement
+                promise_id: AttributeDefinitionEnumeration type software_requirement
                 _type: AttributeDefinitionEnumeration
-              - long_name: Submitted at
-                identifier: Submitted at software_requirement
-                promise_id: AttributeDefinition Submitted at software_requirement
+              - identifier: submittedAt software_requirement
+                long_name: Submitted at
+                promise_id: AttributeDefinition submittedAt software_requirement
                 _type: AttributeDefinition
           - identifier: stakeholder_requirement
             long_name: Stakeholder Requirement
             promise_id: RequirementType stakeholder_requirement
             attribute_definitions:
-              - long_name: Capella ID
-                identifier: Capella ID stakeholder_requirement
-                promise_id: AttributeDefinition Capella ID stakeholder_requirement
+              - identifier: capellaID stakeholder_requirement
+                long_name: Capella ID
+                promise_id: AttributeDefinition capellaID stakeholder_requirement
                 _type: AttributeDefinition
     folders:
       - long_name: Functional Requirements
@@ -91,7 +97,7 @@
                 identifier: REQ-004
                 type: !promise RequirementType stakeholder_requirement
                 attributes:
-                  - definition: !promise AttributeDefinition Capella ID stakeholder_requirement
+                  - definition: !promise AttributeDefinition capellaID stakeholder_requirement
                     value: R-FNC-00002
                     _type: string
         requirements:
@@ -100,18 +106,18 @@
             text: "..."
             type: !promise RequirementType system_requirement
             attributes:
-              - definition: !promise AttributeDefinition Capella ID system_requirement
+              - definition: !promise AttributeDefinition capellaID system_requirement
                 value: R-FNC-00001
                 _type: string
-              - definition: !promise AttributeDefinitionEnumeration Type system_requirement
+              - definition: !promise AttributeDefinitionEnumeration type system_requirement
                 values:
-                  - !promise EnumValue Type Functional
+                  - !promise EnumValue type functional
                 _type: enum
-              - definition: !promise AttributeDefinitionEnumeration Release system_requirement
+              - definition: !promise AttributeDefinitionEnumeration release system_requirement
                 values:
-                  - !promise EnumValue Release Feature Rel. 1
-                  - !promise EnumValue Release Feature Rel. 2
+                  - !promise EnumValue release featureRel.1
+                  - !promise EnumValue release featureRel.2
                 _type: enum
-              - definition: !promise AttributeDefinition Submitted at system_requirement
-                value: 2022-06-30 15:07:18.664000+00:00
+              - definition: !promise AttributeDefinition submittedAt system_requirement
+                value: 2022-06-30 17:07:18.664000+02:00
                 _type: date

--- a/tests/data/changesets/delete.yaml
+++ b/tests/data/changesets/delete.yaml
@@ -1,12 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-rm-bridge contributors
 # SPDX-License-Identifier: Apache-2.0
 
-- parent: !uuid a15e8b60-bf39-47ba-b7c7-74ceecb25c9c
-  delete:
-    data_type_definitions:
-      - !uuid 98aaca05-d47f-4916-a9f9-770dc60aa04f
-    requirement_types:
-      - !uuid cbc96c24-58c9-4292-9dfa-1ecb5ee16a82
 - parent: !uuid 686e198b-8baf-49f9-9d85-24571bd05d93
   delete:
     values:
@@ -16,6 +10,12 @@
     attribute_definitions:
       - !uuid e46d4629-da10-4f7f-954e-146bd2697638
       - long_name Test after migration # dynamically generated object
+- parent: !uuid a15e8b60-bf39-47ba-b7c7-74ceecb25c9c
+  delete:
+    data_type_definitions:
+      - !uuid 98aaca05-d47f-4916-a9f9-770dc60aa04f
+    requirement_types:
+      - !uuid cbc96c24-58c9-4292-9dfa-1ecb5ee16a82
 - parent: !uuid b2c39449-ebbe-43cb-a712-22c740707a8b
   delete:
     attributes:

--- a/tests/data/changesets/delete.yaml
+++ b/tests/data/changesets/delete.yaml
@@ -15,11 +15,11 @@
   delete:
     attribute_definitions:
       - !uuid e46d4629-da10-4f7f-954e-146bd2697638
-      - long_name Test after migration
+      - long_name Test after migration # dynamically generated object
 - parent: !uuid b2c39449-ebbe-43cb-a712-22c740707a8b
   delete:
     attributes:
-      - definition.long_name Release
+      - definition.long_name Release # dynamically generated object
     requirements:
       - !uuid 25ccf941-17ed-4226-847b-040575922283
 - parent: !uuid 3be8d0fc-c693-4b9b-8fa1-d59a9eec6ea4

--- a/tests/data/changesets/mod.yaml
+++ b/tests/data/changesets/mod.yaml
@@ -4,13 +4,15 @@
 - parent: !uuid 686e198b-8baf-49f9-9d85-24571bd05d93
   extend:
     values:
-      - long_name: Non-Functional
-        promise_id: EnumValue Type Non-Functional
+      - identifier: nonFunctional
+        long_name: Non-Functional
+        promise_id: EnumValue type nonFunctional
 - parent: !uuid 98aaca05-d47f-4916-a9f9-770dc60aa04f
   extend:
     values:
-      - long_name: Rel. 1
-        promise_id: EnumValue Release Rel. 1
+      - identifier: rel.1
+        long_name: Rel. 1
+        promise_id: EnumValue release rel.1
   delete:
     values:
       - !uuid e91aa844-584d-451d-a201-2bb7bf13dcb0
@@ -18,9 +20,9 @@
 - parent: !uuid 02bb4cdd-52cc-4fc3-af1c-e57dad8c51de
   extend:
     attribute_definitions:
-      - long_name: Test after migration
-        identifier: Test after migration system_requirement
-        promise_id: AttributeDefinition Test after migration system_requirement
+      - identifier: testAfterMigration system_requirement
+        long_name: Test after migration
+        promise_id: AttributeDefinition testAfterMigration system_requirement
         _type: AttributeDefinition
 - parent: !uuid cbc96c24-58c9-4292-9dfa-1ecb5ee16a82
   modify:
@@ -36,18 +38,18 @@
         _type: string
       - definition: !uuid 12d97ef4-8b6e-4d45-8b3d-a1b6fe5b8aed
         values:
-          - !promise EnumValue Type Non-Functional
+          - !promise EnumValue type nonFunctional
         _type: enum
       - definition: !uuid e46d4629-da10-4f7f-954e-146bd2697638
         values:
-          - !promise EnumValue Release Rel. 1
+          - !promise EnumValue release rel.1
         _type: enum
 - parent: !uuid 25ccf941-17ed-4226-847b-040575922283
   modify:
     long_name: Non-Function Requirement
   extend:
     attributes:
-      - definition: !promise AttributeDefinition Test after migration system_requirement
+      - definition: !promise AttributeDefinition testAfterMigration system_requirement
         value: New
         _type: string
   delete:
@@ -59,7 +61,7 @@
 - parent: !uuid 6708cf60-2f06-4ccf-9973-21a035415ccb
   modify:
     values:
-      - !promise EnumValue Type Non-Functional
+      - !promise EnumValue type nonFunctional
 - parent: !uuid 9a9b5a8f-a6ad-4610-9e88-3b5e9c943c19
   modify:
     long_name: Functional Requirements

--- a/tests/data/model/RM Bridge.capella
+++ b/tests/data/model/RM Bridge.capella
@@ -1836,47 +1836,48 @@ The predator is far away</bodies>
         <ownedExtensions xsi:type="CapellaRequirements:CapellaTypesFolder" id="a15e8b60-bf39-47ba-b7c7-74ceecb25c9c"
             ReqIFIdentifier="-2" ReqIFLongName="Types">
           <ownedDefinitionTypes xsi:type="Requirements:EnumerationDataTypeDefinition"
-              id="686e198b-8baf-49f9-9d85-24571bd05d93" ReqIFLongName="Type">
+              id="686e198b-8baf-49f9-9d85-24571bd05d93" ReqIFIdentifier="type" ReqIFLongName="Type">
             <specifiedValues xsi:type="Requirements:EnumValue" id="61d37f6e-b821-49fa-b68d-c4ff48b8cbbf"
-                ReqIFLongName="Unset"/>
+                ReqIFIdentifier="unset" ReqIFLongName="Unset"/>
             <specifiedValues xsi:type="Requirements:EnumValue" id="5a03662a-d602-4524-8706-5bf83275ee2a"
-                ReqIFLongName="Functional"/>
+                ReqIFIdentifier="functional" ReqIFLongName="Functional"/>
           </ownedDefinitionTypes>
           <ownedDefinitionTypes xsi:type="Requirements:EnumerationDataTypeDefinition"
-              id="98aaca05-d47f-4916-a9f9-770dc60aa04f" ReqIFLongName="Release">
+              id="98aaca05-d47f-4916-a9f9-770dc60aa04f" ReqIFIdentifier="release"
+              ReqIFLongName="Release">
             <specifiedValues xsi:type="Requirements:EnumValue" id="e91aa844-584d-451d-a201-2bb7bf13dcb0"
-                ReqIFLongName="Feature Rel. 1"/>
+                ReqIFIdentifier="featureRel.1" ReqIFLongName="Feature Rel. 1"/>
             <specifiedValues xsi:type="Requirements:EnumValue" id="3a39327a-a40d-47a6-a054-d29b1851e478"
-                ReqIFLongName="Feature Rel. 2"/>
+                ReqIFIdentifier="featureRel.2" ReqIFLongName="Feature Rel. 2"/>
           </ownedDefinitionTypes>
           <ownedTypes xsi:type="Requirements:RequirementType" id="02bb4cdd-52cc-4fc3-af1c-e57dad8c51de"
               ReqIFIdentifier="system_requirement" ReqIFLongName="System Requirement">
             <ownedAttributes xsi:type="Requirements:AttributeDefinition" id="87af9e2a-41b6-4962-a57e-eb695e0a03ad"
-                ReqIFIdentifier="Capella ID system_requirement" ReqIFLongName="Capella ID"/>
+                ReqIFIdentifier="capellaID system_requirement" ReqIFLongName="Capella ID"/>
             <ownedAttributes xsi:type="Requirements:AttributeDefinitionEnumeration"
-                id="12d97ef4-8b6e-4d45-8b3d-a1b6fe5b8aed" ReqIFIdentifier="Type system_requirement"
+                id="12d97ef4-8b6e-4d45-8b3d-a1b6fe5b8aed" ReqIFIdentifier="type system_requirement"
                 ReqIFLongName="Type" definitionType="#686e198b-8baf-49f9-9d85-24571bd05d93"/>
             <ownedAttributes xsi:type="Requirements:AttributeDefinition" id="5c266812-9458-4cf6-a35f-41ea34d96cd7"
-                ReqIFIdentifier="Submitted at system_requirement" ReqIFLongName="Submitted at"/>
+                ReqIFIdentifier="submittedAt system_requirement" ReqIFLongName="Submitted at"/>
             <ownedAttributes xsi:type="Requirements:AttributeDefinitionEnumeration"
-                id="e46d4629-da10-4f7f-954e-146bd2697638" ReqIFIdentifier="Release system_requirement"
+                id="e46d4629-da10-4f7f-954e-146bd2697638" ReqIFIdentifier="release system_requirement"
                 ReqIFLongName="Release" definitionType="#98aaca05-d47f-4916-a9f9-770dc60aa04f"
                 multiValued="true"/>
           </ownedTypes>
           <ownedTypes xsi:type="Requirements:RequirementType" id="bde333d5-141d-4ced-acf8-6f8507337c90"
               ReqIFIdentifier="software_requirement" ReqIFLongName="Software Requirement">
             <ownedAttributes xsi:type="Requirements:AttributeDefinition" id="7c3a47a0-efff-4cda-baae-0ef3bfb2cbed"
-                ReqIFIdentifier="Capella ID software_requirement" ReqIFLongName="Capella ID"/>
+                ReqIFIdentifier="capellaID software_requirement" ReqIFLongName="Capella ID"/>
             <ownedAttributes xsi:type="Requirements:AttributeDefinitionEnumeration"
-                id="79ffc1c8-38d3-4c65-a45f-c9f52de30834" ReqIFIdentifier="Type software_requirement"
+                id="79ffc1c8-38d3-4c65-a45f-c9f52de30834" ReqIFIdentifier="type software_requirement"
                 ReqIFLongName="Type" definitionType="#686e198b-8baf-49f9-9d85-24571bd05d93"/>
             <ownedAttributes xsi:type="Requirements:AttributeDefinition" id="ec1b5268-2a6a-4c05-b741-8ae05ae2bde6"
-                ReqIFIdentifier="Submitted at software_requirement" ReqIFLongName="Submitted at"/>
+                ReqIFIdentifier="submittedAt software_requirement" ReqIFLongName="Submitted at"/>
           </ownedTypes>
           <ownedTypes xsi:type="Requirements:RequirementType" id="cbc96c24-58c9-4292-9dfa-1ecb5ee16a82"
               ReqIFIdentifier="stakeholder_requirement" ReqIFLongName="Stakeholder Requirement">
             <ownedAttributes xsi:type="Requirements:AttributeDefinition" id="e949bf20-4abe-42dc-ac63-bf74b24571bb"
-                ReqIFIdentifier="Capella ID stakeholder_requirement" ReqIFLongName="Capella ID"/>
+                ReqIFIdentifier="capellaID stakeholder_requirement" ReqIFLongName="Capella ID"/>
           </ownedTypes>
         </ownedExtensions>
       </ownedExtensions>

--- a/tests/data/snapshots/snapshot.yaml
+++ b/tests/data/snapshots/snapshot.yaml
@@ -10,39 +10,55 @@ modules:
   - id: project/space/example title
     long_name: example title
     data_types: # Enumeration Data Type Definitions
-      Type:
-        - Unset
-        - Functional
-      Release:
-        - Feature Rel. 1
-        - Feature Rel. 2
+      type:
+        long_name: Type
+        values:
+          - id: unset
+            long_name: Unset
+          - id: functional
+            long_name: Functional
+      release:
+        long_name: Release
+        values:
+          - id: featureRel.1
+            long_name: Feature Rel. 1
+          - id: featureRel.2
+            long_name: Feature Rel. 2
 
     requirement_types: # WorkItemTypes
       system_requirement:
         long_name: System Requirement
         attributes: # Field Definitions, we don't need the IDs
-          Capella ID: # Field name
+          capellaID: # Field name
+            long_name: Capella ID
             type: String # -> AttributeDefinition
-          Type:
+          type:
+            long_name: Type
             type: Enum
-          Submitted at:
+          submittedAt:
+            long_name: Submitted at
             type: Date # -> AttributeDefinition
-          Release:
+          release:
+            long_name: Release
             type: Enum
             multi_values: true
       software_requirement:
         long_name: Software Requirement
         attributes:
-          Capella ID:
+          capellaID:
+            long_name: Capella ID
             type: String
-          Type:
+          type:
+            long_name: Type
             type: Enum
-          Submitted at:
+          submittedAt:
+            long_name: Submitted at
             type: Date
       stakeholder_requirement:
         long_name: Stakeholder Requirement
         attributes:
-          Capella ID:
+          capellaID:
+            long_name: Capella ID
             type: String
 
     items: # WorkItems
@@ -57,12 +73,12 @@ modules:
             text: ...
             type: system_requirement
             attributes: # Fields
-              Capella ID: R-FNC-00001 # name, value pair
-              Type: [Functional] # values in a list for enum fields
-              Release:
-                - Feature Rel. 1
-                - Feature Rel. 2
-              Submitted at: 2022-06-30 17:07:18.664000+02:00 # datetime.datetime for dates
+              capellaID: R-FNC-00001 # name, value pair
+              type: [functional] # values in a list for enum fields
+              release:
+                - featureRel.1
+                - featureRel.2
+              submittedAt: 2022-06-30 17:07:18.664000+02:00 # datetime.datetime for dates
           - id: REQ-003
             long_name: Kinds
             type: software_requirement
@@ -71,4 +87,4 @@ modules:
                 long_name: Kind Requirement
                 type: stakeholder_requirement
                 attributes:
-                  Capella ID: R-FNC-00002
+                  capellaID: R-FNC-00002

--- a/tests/data/snapshots/snapshot1.yaml
+++ b/tests/data/snapshots/snapshot1.yaml
@@ -10,40 +10,57 @@ modules:
   - id: project/space/example title
     long_name: example title
     data_types:
-      Type:
-        - Unset
-        - Functional
-        - Non-Functional
-      Release:
-        - Rel. 1
+      type:
+        long_name: Type
+        values:
+          - id: unset
+            long_name: Unset
+          - id: functional
+            long_name: Functional
+          - id: nonFunctional
+            long_name: Non-Functional
+      release:
+        long_name: Release
+        values:
+          - id: rel.1
+            long_name: Rel. 1
     requirement_types:
       system_requirement:
         long_name: System Requirement
         attributes:
-          Capella ID:
+          capellaID:
+            long_name: Capella ID
             type: String
-          Type:
+          type:
+            long_name: Type
             type: Enum
-          Submitted at:
+          submittedAt:
+            long_name: Submitted at
             type: Date
-          Release:
+          release:
+            long_name: Release
             type: Enum
             multi_values: true
-          Test after migration:
+          testAfterMigration:
+            long_name: Test after migration
             type: String
       software_requirement:
         long_name: Software Requirement
         attributes:
-          Capella ID:
+          capellaID:
+            long_name: Capella ID
             type: String
-          Type:
+          type:
+            long_name: Type
             type: Enum
-          Submitted at:
+          submittedAt:
+            long_name: Submitted at
             type: Date
       stakeholder_requirement:
         long_name: Stakeholders Requirement
         attributes:
-          Capella ID:
+          capellaID:
+            long_name: Capella ID
             type: String
     items:
       - id: REQ-001
@@ -51,20 +68,20 @@ modules:
         text: <p>Changed Test Description</p>
         type: system_requirement
         attributes:
-          Capella ID: RF-NFNC-00001
-          Type: [Non-Functional]
-          Release:
-            - Rel. 1
+          capellaID: RF-NFNC-00001
+          type: [nonFunctional]
+          release:
+            - rel.1
         children:
           - id: REQ-002
             long_name: Non-Function Requirement
             text: ...
             type: system_requirement
             attributes:
-              Capella ID: R-NFNC-00002
-              Type: [Non-Functional]
-              Submitted at: 2022-06-30 17:07:18.664000+02:00
-              Test after migration: New
+              capellaID: R-NFNC-00002
+              type: [nonFunctional]
+              submittedAt: 2022-06-30 17:07:18.664000+02:00
+              testAfterMigration: New
       - id: REQ-003
         long_name: Functional Requirements
         text: <p>Brand new</p>
@@ -74,5 +91,5 @@ modules:
             long_name: Function Requirement
             type: software_requirement
             attributes:
-              Capella ID: R-FNC-00001
-              Type: [Unset]
+              capellaID: R-FNC-00001
+              type: [unset]

--- a/tests/data/snapshots/snapshot2.yaml
+++ b/tests/data/snapshots/snapshot2.yaml
@@ -10,27 +10,37 @@ modules:
   - id: project/space/example title
     long_name: example title
     data_types:
-      Type:
-        - Unset
-        - Non-Functional
+      type:
+        long_name: Type
+        values:
+          - id: unset
+            long_name: Unset
+          - id: nonFunctional
+            long_name: Non-Functional
     requirement_types:
       system_requirement:
         long_name: System Requirement
         attributes:
-          Capella ID:
+          capellaID:
+            long_name: Capella ID
             type: String
-          Type:
+          type:
+            long_name: Type
             type: Enum
-          Submitted at:
+          submittedAt:
+            long_name: Submitted at
             type: Date
       software_requirement:
         long_name: Software Requirement
         attributes:
-          Capella ID:
+          capellaID:
+            long_name: Capella ID
             type: String
-          Type:
+          type:
+            long_name: Type
             type: Enum
-          Submitted at:
+          submittedAt:
+            long_name: Submitted at
             type: Date
     items:
       - id: REQ-001
@@ -38,6 +48,6 @@ modules:
         text: <p>Changed Test Description</p>
         type: system_requirement
         attributes:
-          Capella ID: RF-NFNC-00001
-          Type: [Non-Functional]
+          capellaID: RF-NFNC-00001
+          type: [nonFunctional]
         children: []

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -435,15 +435,14 @@ class TestModActions(ActionsTest):
         tracker = copy.deepcopy(self.tracker)
         titem = tracker["items"][0]
         titem["imagination"] = 1
-        message_end = (
-            "Invalid module 'project/space/example title'. Invalid "
-            "workitem 'REQ-001'. imagination isn't defined on Folder"
-        )
 
         with caplog.at_level(logging.ERROR):
             self.tracker_change(migration_model, tracker, gather_logs=False)
 
-        assert caplog.messages[0].endswith(message_end)
+        assert "project/space/example title" in caplog.messages[0]
+        assert "REQ-001" in caplog.messages[0]
+        assert "imagination" in caplog.messages[0]
+        assert "Folder" in caplog.messages[0]
 
     def test_InvalidAttributeDefinition_errors_are_gathered(
         self, migration_model: capellambse.MelodyModel


### PR DESCRIPTION
This PR anticipates the latest changes to the snapshot interface, using just the identifiers of objects. The documentation was changed too and the corresponding warning section was removed. the `JSON`schema needed an update too.