### PR TITLE
Anticipate snapshot changes

### DIFF
--- a/capella_rm_bridge/changeset/actiontypes.py
+++ b/capella_rm_bridge/changeset/actiontypes.py
@@ -122,6 +122,7 @@ class EnumAttributeDefinition(AttributeDefinition, total=False):
 
     values: list[str]
     multi_values: bool
+    type_id: str
 
 
 class InvalidSnapshotModule(Exception):

--- a/capella_rm_bridge/changeset/snapshot_input.schema.json
+++ b/capella_rm_bridge/changeset/snapshot_input.schema.json
@@ -58,28 +58,12 @@
               "additionalProperties": false,
               "patternProperties": {
                 ".": {
-                  "description": "The values that are available for this EnumerationDataTypeDefinition. They are sometimes called \"options\"",
-                  "type": "object",
-                  "properties": {
-                    "long_name": {
-                      "description": "Value of the \"Long Name\" field in Capella. Here it is the long name of the EnumerationDataTypeDefinition.",
-                      "type": "string"
-                    },
-                    "values": {
-                      "description": "EnumValues in Capella.",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "description": "Value of the \"Identifier\" field in Capella. Here it is the identifier of the EnumValue.",
-                            "type": "string"
-                          },
-                          "long_name": {
-                            "description": "Value of the \"Long Name\" field in Capella. Here it is the long name of the EnumValue.",
-                            "type": "string"
-                          }
-                        }
+                  "description": "The values that are available for this EnumerationAttribute. They are sometimes called \"options\"",
+                  "type": "array",
+                  "items": {
+                    "patternProperties": {
+                      ".": {
+                        "type": "string"
                       }
                     }
                   }
@@ -143,6 +127,10 @@
                                 "multi_values": {
                                   "description": "Whether the Enum Attribute can have multiple values (true) or must always have exactly one value (false).",
                                   "type": "boolean"
+                                },
+                                "type_id": {
+                                  "description": "The EnumerationDataTypeDefinition identifier for assication of the available options.",
+                                  "type": "string"
                                 }
                               },
                               "additionalProperties": false

--- a/tests/data/changesets/create.yaml
+++ b/tests/data/changesets/create.yaml
@@ -10,27 +10,27 @@
       - long_name: Types
         identifier: "-2"
         data_type_definitions:
-          - identifier: type
-            long_name: Type
+          - identifier: eType
+            long_name: eType
             values:
               - identifier: unset
-                long_name: Unset
-                promise_id: EnumValue type unset
+                long_name: unset
+                promise_id: EnumValue eType unset
               - identifier: functional
-                long_name: Functional
-                promise_id: EnumValue type functional
-            promise_id: EnumerationDataTypeDefinition type
+                long_name: functional
+                promise_id: EnumValue eType functional
+            promise_id: EnumerationDataTypeDefinition eType
             _type: EnumerationDataTypeDefinition
-          - identifier: release
-            long_name: Release
+          - identifier: eRelease
+            long_name: eRelease
             values:
               - identifier: featureRel.1
-                long_name: Feature Rel. 1
-                promise_id: EnumValue release featureRel.1
+                long_name: featureRel.1
+                promise_id: EnumValue eRelease featureRel.1
               - identifier: featureRel.2
-                long_name: Feature Rel. 2
-                promise_id: EnumValue release featureRel.2
-            promise_id: EnumerationDataTypeDefinition release
+                long_name: featureRel.2
+                promise_id: EnumValue eRelease featureRel.2
+            promise_id: EnumerationDataTypeDefinition eRelease
             _type: EnumerationDataTypeDefinition
         requirement_types:
           - identifier: system_requirement
@@ -43,7 +43,7 @@
                 _type: AttributeDefinition
               - identifier: type system_requirement
                 long_name: Type
-                data_type: !promise EnumerationDataTypeDefinition type
+                data_type: !promise EnumerationDataTypeDefinition eType
                 multi_valued: false
                 promise_id: AttributeDefinitionEnumeration type system_requirement
                 _type: AttributeDefinitionEnumeration
@@ -53,7 +53,7 @@
                 _type: AttributeDefinition
               - identifier: release system_requirement
                 long_name: Release
-                data_type: !promise EnumerationDataTypeDefinition release
+                data_type: !promise EnumerationDataTypeDefinition eRelease
                 multi_valued: true
                 promise_id: AttributeDefinitionEnumeration release system_requirement
                 _type: AttributeDefinitionEnumeration
@@ -67,7 +67,7 @@
                 _type: AttributeDefinition
               - identifier: type software_requirement
                 long_name: Type
-                data_type: !promise EnumerationDataTypeDefinition type
+                data_type: !promise EnumerationDataTypeDefinition eType
                 multi_valued: false
                 promise_id: AttributeDefinitionEnumeration type software_requirement
                 _type: AttributeDefinitionEnumeration
@@ -111,12 +111,12 @@
                 _type: string
               - definition: !promise AttributeDefinitionEnumeration type system_requirement
                 values:
-                  - !promise EnumValue type functional
+                  - !promise EnumValue eType functional
                 _type: enum
               - definition: !promise AttributeDefinitionEnumeration release system_requirement
                 values:
-                  - !promise EnumValue release featureRel.1
-                  - !promise EnumValue release featureRel.2
+                  - !promise EnumValue eRelease featureRel.1
+                  - !promise EnumValue eRelease featureRel.2
                 _type: enum
               - definition: !promise AttributeDefinition submittedAt system_requirement
                 value: 2022-06-30 17:07:18.664000+02:00

--- a/tests/data/changesets/mod.yaml
+++ b/tests/data/changesets/mod.yaml
@@ -5,14 +5,14 @@
   extend:
     values:
       - identifier: nonFunctional
-        long_name: Non-Functional
-        promise_id: EnumValue type nonFunctional
+        long_name: nonFunctional
+        promise_id: EnumValue eType nonFunctional
 - parent: !uuid 98aaca05-d47f-4916-a9f9-770dc60aa04f
   extend:
     values:
       - identifier: rel.1
-        long_name: Rel. 1
-        promise_id: EnumValue release rel.1
+        long_name: rel.1
+        promise_id: EnumValue eRelease rel.1
   delete:
     values:
       - !uuid e91aa844-584d-451d-a201-2bb7bf13dcb0
@@ -38,11 +38,11 @@
         _type: string
       - definition: !uuid 12d97ef4-8b6e-4d45-8b3d-a1b6fe5b8aed
         values:
-          - !promise EnumValue type nonFunctional
+          - !promise EnumValue eType nonFunctional
         _type: enum
       - definition: !uuid e46d4629-da10-4f7f-954e-146bd2697638
         values:
-          - !promise EnumValue release rel.1
+          - !promise EnumValue eRelease rel.1
         _type: enum
 - parent: !uuid 25ccf941-17ed-4226-847b-040575922283
   modify:
@@ -61,7 +61,7 @@
 - parent: !uuid 6708cf60-2f06-4ccf-9973-21a035415ccb
   modify:
     values:
-      - !promise EnumValue type nonFunctional
+      - !promise EnumValue eType nonFunctional
 - parent: !uuid 9a9b5a8f-a6ad-4610-9e88-3b5e9c943c19
   modify:
     long_name: Functional Requirements

--- a/tests/data/model/RM Bridge.capella
+++ b/tests/data/model/RM Bridge.capella
@@ -1836,19 +1836,19 @@ The predator is far away</bodies>
         <ownedExtensions xsi:type="CapellaRequirements:CapellaTypesFolder" id="a15e8b60-bf39-47ba-b7c7-74ceecb25c9c"
             ReqIFIdentifier="-2" ReqIFLongName="Types">
           <ownedDefinitionTypes xsi:type="Requirements:EnumerationDataTypeDefinition"
-              id="686e198b-8baf-49f9-9d85-24571bd05d93" ReqIFIdentifier="type" ReqIFLongName="Type">
+              id="686e198b-8baf-49f9-9d85-24571bd05d93" ReqIFIdentifier="eType" ReqIFLongName="eType">
             <specifiedValues xsi:type="Requirements:EnumValue" id="61d37f6e-b821-49fa-b68d-c4ff48b8cbbf"
-                ReqIFIdentifier="unset" ReqIFLongName="Unset"/>
+                ReqIFIdentifier="unset" ReqIFLongName="unset"/>
             <specifiedValues xsi:type="Requirements:EnumValue" id="5a03662a-d602-4524-8706-5bf83275ee2a"
-                ReqIFIdentifier="functional" ReqIFLongName="Functional"/>
+                ReqIFIdentifier="functional" ReqIFLongName="functional"/>
           </ownedDefinitionTypes>
           <ownedDefinitionTypes xsi:type="Requirements:EnumerationDataTypeDefinition"
-              id="98aaca05-d47f-4916-a9f9-770dc60aa04f" ReqIFIdentifier="release"
-              ReqIFLongName="Release">
+              id="98aaca05-d47f-4916-a9f9-770dc60aa04f" ReqIFIdentifier="eRelease"
+              ReqIFLongName="eRelease">
             <specifiedValues xsi:type="Requirements:EnumValue" id="e91aa844-584d-451d-a201-2bb7bf13dcb0"
-                ReqIFIdentifier="featureRel.1" ReqIFLongName="Feature Rel. 1"/>
+                ReqIFIdentifier="featureRel.1" ReqIFLongName="featureRel.1"/>
             <specifiedValues xsi:type="Requirements:EnumValue" id="3a39327a-a40d-47a6-a054-d29b1851e478"
-                ReqIFIdentifier="featureRel.2" ReqIFLongName="Feature Rel. 2"/>
+                ReqIFIdentifier="featureRel.2" ReqIFLongName="featureRel.2"/>
           </ownedDefinitionTypes>
           <ownedTypes xsi:type="Requirements:RequirementType" id="02bb4cdd-52cc-4fc3-af1c-e57dad8c51de"
               ReqIFIdentifier="system_requirement" ReqIFLongName="System Requirement">

--- a/tests/data/snapshots/snapshot.yaml
+++ b/tests/data/snapshots/snapshot.yaml
@@ -10,20 +10,12 @@ modules:
   - id: project/space/example title
     long_name: example title
     data_types: # Enumeration Data Type Definitions
-      type:
-        long_name: Type
-        values:
-          - id: unset
-            long_name: Unset
-          - id: functional
-            long_name: Functional
-      release:
-        long_name: Release
-        values:
-          - id: featureRel.1
-            long_name: Feature Rel. 1
-          - id: featureRel.2
-            long_name: Feature Rel. 2
+      eType:
+        - unset
+        - functional
+      eRelease:
+        - featureRel.1
+        - featureRel.2
 
     requirement_types: # WorkItemTypes
       system_requirement:
@@ -35,12 +27,14 @@ modules:
           type:
             long_name: Type
             type: Enum
+            type_id: eType
           submittedAt:
             long_name: Submitted at
             type: Date # -> AttributeDefinition
           release:
             long_name: Release
             type: Enum
+            type_id: eRelease
             multi_values: true
       software_requirement:
         long_name: Software Requirement
@@ -51,6 +45,7 @@ modules:
           type:
             long_name: Type
             type: Enum
+            type_id: eType
           submittedAt:
             long_name: Submitted at
             type: Date

--- a/tests/data/snapshots/snapshot1.yaml
+++ b/tests/data/snapshots/snapshot1.yaml
@@ -10,20 +10,12 @@ modules:
   - id: project/space/example title
     long_name: example title
     data_types:
-      type:
-        long_name: Type
-        values:
-          - id: unset
-            long_name: Unset
-          - id: functional
-            long_name: Functional
-          - id: nonFunctional
-            long_name: Non-Functional
-      release:
-        long_name: Release
-        values:
-          - id: rel.1
-            long_name: Rel. 1
+      eType:
+        - unset
+        - functional
+        - nonFunctional
+      eRelease:
+        - rel.1
     requirement_types:
       system_requirement:
         long_name: System Requirement
@@ -34,12 +26,14 @@ modules:
           type:
             long_name: Type
             type: Enum
+            type_id: eType
           submittedAt:
             long_name: Submitted at
             type: Date
           release:
             long_name: Release
             type: Enum
+            type_id: eRelease
             multi_values: true
           testAfterMigration:
             long_name: Test after migration
@@ -53,6 +47,7 @@ modules:
           type:
             long_name: Type
             type: Enum
+            type_id: eType
           submittedAt:
             long_name: Submitted at
             type: Date

--- a/tests/data/snapshots/snapshot2.yaml
+++ b/tests/data/snapshots/snapshot2.yaml
@@ -10,13 +10,9 @@ modules:
   - id: project/space/example title
     long_name: example title
     data_types:
-      type:
-        long_name: Type
-        values:
-          - id: unset
-            long_name: Unset
-          - id: nonFunctional
-            long_name: Non-Functional
+      eType:
+        - unset
+        - nonFunctional
     requirement_types:
       system_requirement:
         long_name: System Requirement
@@ -27,6 +23,7 @@ modules:
           type:
             long_name: Type
             type: Enum
+            type_id: eType
           submittedAt:
             long_name: Submitted at
             type: Date
@@ -39,6 +36,7 @@ modules:
           type:
             long_name: Type
             type: Enum
+            type_id: eType
           submittedAt:
             long_name: Submitted at
             type: Date


### PR DESCRIPTION
This PR anticipates the structural changes to the snapshot interface. There are no `long_name`s anymore in the `data_types` section. Instead only id's are used.